### PR TITLE
Add Cypress Selector Helper extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-"# Milifaru" 
+# Milifaru
+
+Chrome extension **Cypress Selector Helper**.
+
+## Development
+
+The extension source is located under `manifest.json` and `src/`.
+
+## Install (Load Unpacked)
+
+1. Open Chrome and go to `chrome://extensions`.
+2. Enable **Developer mode**.
+3. Click **Load unpacked** and select the project folder.
+4. The extension will appear in the toolbar.
+

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,43 @@
+{
+  "manifest_version": 3,
+  "name": "Cypress Selector Helper",
+  "version": "1.0.0",
+  "description": "Helper for generating unique CSS selectors for Cypress",
+  "action": {
+    "default_popup": "src/popup.html"
+  },
+  "background": {
+    "service_worker": "src/background.js",
+    "type": "module"
+  },
+  "permissions": ["activeTab", "scripting", "storage", "commands"],
+  "host_permissions": ["<all_urls>"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["src/content.js"],
+      "css": ["src/highlight.css"],
+      "run_at": "document_idle"
+    }
+  ],
+  "commands": {
+    "toggle-picker": {
+      "suggested_key": {
+        "default": "Alt+S"
+      },
+      "description": "Toggle picker"
+    },
+    "copy-selector": {
+      "suggested_key": {
+        "default": "Alt+C"
+      },
+      "description": "Copy current selector"
+    },
+    "switch-mode": {
+      "suggested_key": {
+        "default": "Alt+X"
+      },
+      "description": "Switch mode"
+    }
+  }
+}

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,31 @@
+import { getSettings, setSettings } from './storage.js';
+
+chrome.commands.onCommand.addListener(async command => {
+  if (command === 'toggle-picker') {
+    const tabs = await chrome.tabs.query({});
+    for (const tab of tabs) chrome.tabs.sendMessage(tab.id, { type: 'TOGGLE_PICKER' });
+  } else if (command === 'copy-selector') {
+    chrome.runtime.sendMessage({ type: 'COPY_SELECTED' });
+  } else if (command === 'switch-mode') {
+    const s = await getSettings();
+    const mode = s.mode === 'get' ? 'contains' : 'get';
+    await setSettings({ mode });
+    chrome.runtime.sendMessage({ type: 'MODE_CHANGED', mode });
+  }
+});
+
+chrome.runtime.onMessage.addListener((msg, sender) => {
+  if (msg.type === 'TOGGLE_PICKER') {
+    if (sender.tab) {
+      chrome.tabs.sendMessage(sender.tab.id, { type: 'TOGGLE_PICKER' });
+    } else {
+      chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+        for (const tab of tabs) chrome.tabs.sendMessage(tab.id, { type: 'TOGGLE_PICKER' });
+      });
+    }
+  } else if (msg.type === 'PICKED') {
+    chrome.runtime.sendMessage(msg);
+  } else if (msg.type === 'COPY_SELECTED') {
+    chrome.runtime.sendMessage(msg);
+  }
+});

--- a/src/content.js
+++ b/src/content.js
@@ -1,0 +1,92 @@
+let picking = false;
+let lastEl = null;
+let overlay, tooltip, settings;
+let bestSelector, textBased;
+
+(async () => {
+  ({ bestSelector, textBased } = await import(chrome.runtime.getURL('src/selectorEngine.js')));
+  const storage = await import(chrome.runtime.getURL('src/storage.js'));
+  settings = await storage.getSettings();
+  overlay = document.createElement('div');
+  overlay.className = 'selector-helper-overlay';
+  tooltip = document.createElement('div');
+  tooltip.className = 'selector-helper-tooltip';
+  overlay.style.display = 'none';
+  tooltip.style.display = 'none';
+  document.documentElement.appendChild(overlay);
+  document.documentElement.appendChild(tooltip);
+})();
+
+function throttle(fn, wait) {
+  let t = 0;
+  return function (...args) {
+    const now = Date.now();
+    if (now - t >= wait) {
+      t = now;
+      fn.apply(this, args);
+    }
+  };
+}
+
+const moveHandler = throttle(e => {
+  if (!picking) return;
+  const el = e.target;
+  if (!el || el === overlay || el === tooltip) return;
+  lastEl = el;
+  const rect = el.getBoundingClientRect();
+  overlay.style.display = 'block';
+  overlay.style.top = `${rect.top + window.scrollY}px`;
+  overlay.style.left = `${rect.left + window.scrollX}px`;
+  overlay.style.width = `${rect.width}px`;
+  overlay.style.height = `${rect.height}px`;
+  const res = bestSelector(el, settings);
+  tooltip.textContent = res.selector + (res.unique ? ' ✓' : ' ✗');
+  tooltip.style.display = 'block';
+  tooltip.style.top = `${rect.top + window.scrollY}px`;
+  tooltip.style.left = `${rect.left + window.scrollX}px`;
+}, 80);
+
+document.addEventListener('mousemove', moveHandler, true);
+
+document.addEventListener('click', e => {
+  if (!picking) return;
+  e.preventDefault();
+  e.stopPropagation();
+  picking = false;
+  overlay.style.display = 'none';
+  tooltip.style.display = 'none';
+  if (!lastEl) return;
+  const root = lastEl.getRootNode && lastEl.getRootNode();
+  const res = bestSelector(lastEl, settings);
+  const textAlt = textBased(lastEl);
+  let context;
+  let framePath;
+  if (root instanceof ShadowRoot) {
+    context = 'shadow';
+  }
+  if (window.top !== window) {
+    context = 'iframe';
+    framePath = [];
+    let win = window;
+    while (win !== win.top) {
+      const parent = win.parent;
+      const frames = Array.from(parent.document.querySelectorAll('iframe'));
+      const idx = frames.findIndex(f => f.contentWindow === win);
+      framePath.unshift(idx);
+      win = parent;
+    }
+  }
+  chrome.runtime.sendMessage({ type: 'PICKED', selector: res.selector, top: res.top, unique: res.unique, textAlt, context, framePath });
+}, true);
+
+chrome.runtime.onMessage.addListener(msg => {
+  if (msg.type === 'TOGGLE_PICKER') {
+    picking = !picking;
+    if (!picking) {
+      overlay.style.display = 'none';
+      tooltip.style.display = 'none';
+    }
+  } else if (msg.type === 'UPDATE_SETTINGS') {
+    import(chrome.runtime.getURL('src/storage.js')).then(m => m.getSettings().then(s => (settings = s)));
+  }
+});

--- a/src/highlight.css
+++ b/src/highlight.css
@@ -1,0 +1,18 @@
+.selector-helper-overlay {
+  position: absolute;
+  pointer-events: none;
+  z-index: 2147483647;
+  box-shadow: 0 0 0 2px #00bcd4, 0 0 6px rgba(0,188,212,0.5);
+}
+.selector-helper-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: #00bcd4;
+  color: #fff;
+  font-size: 12px;
+  padding: 2px 4px;
+  border-radius: 4px;
+  z-index: 2147483647;
+  white-space: nowrap;
+  transform: translateY(-100%);
+}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,37 @@
+const messages = {
+  en: {
+    title: 'Cypress Selector Helper',
+    enablePicker: 'Enable picker',
+    copy: 'Copy',
+    unique: 'unique',
+    mode: 'Mode',
+    get: 'cy.get',
+    contains: 'contains',
+    history: 'History',
+    allowNth: 'Allow :nth-of-type',
+    maxDepth: 'Max depth',
+    shadowWarning: 'Element is inside shadow DOM. Adjust your Cypress code.',
+    iframeWarning: 'Element is inside iframe. Switch to the frame first.',
+    noText: 'no text'
+  },
+  ru: {
+    title: 'Cypress Selector Helper',
+    enablePicker: 'Включить пипетку',
+    copy: 'Копировать',
+    unique: 'уникально',
+    mode: 'Режим',
+    get: 'cy.get',
+    contains: 'contains',
+    history: 'История',
+    allowNth: 'Разрешить :nth-of-type',
+    maxDepth: 'Макс. глубина',
+    shadowWarning: 'Элемент в Shadow DOM. Нужен доступ к теневому корню.',
+    iframeWarning: 'Элемент внутри iframe. Переключитесь в iframe.',
+    noText: 'нет текста'
+  }
+};
+
+export const lang = navigator.language && navigator.language.startsWith('ru') ? 'ru' : 'en';
+export function t(key) {
+  return messages[lang][key] || key;
+}

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,0 +1,7 @@
+body { font-family: Arial, sans-serif; margin: 10px; width: 300px; }
+#last, #preview { margin-top: 10px; }
+#bestSelector { width: 180px; }
+#topCandidates label { display: block; font-size: 12px; }
+#historyList { max-height: 120px; overflow-y: auto; font-size: 12px; }
+.warning { color: #d32f2f; margin-top: 10px; font-size: 12px; }
+.disabled { color: #999; }

--- a/src/popup.html
+++ b/src/popup.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8"/>
+  <link rel="stylesheet" href="popup.css"/>
+</head>
+<body>
+  <h1 id="title"></h1>
+  <label><input type="checkbox" id="pickerToggle"/> <span id="enableLabel"></span></label>
+  <div id="last">
+    <input id="bestSelector" readonly/>
+    <button id="copySelector"></button>
+    <span id="uniqueFlag"></span>
+  </div>
+  <div id="topCandidates"></div>
+  <div id="modeSwitch">
+    <span id="modeLabel"></span>
+    <label><input type="radio" name="mode" value="get"/> cy.get</label>
+    <label><input type="radio" name="mode" value="contains"/> contains</label>
+  </div>
+  <div id="preview"><code id="previewText"></code> <button id="copyPreview"></button></div>
+  <div id="contextWarning" class="warning" style="display:none"></div>
+  <div id="historySection">
+    <h3 id="historyLabel"></h3>
+    <ul id="historyList"></ul>
+  </div>
+  <fieldset id="settingsSection">
+    <legend>Settings</legend>
+    <label><input type="checkbox" id="allowNth"/> <span id="allowNthLabel"></span></label>
+    <label><span id="maxDepthLabel"></span> <input type="number" id="maxDepth" min="1" max="5"/></label>
+  </fieldset>
+  <script type="module" src="popup.js"></script>
+</body>
+</html>

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,0 +1,138 @@
+import { getSettings, setSettings, pushHistory, getHistory } from './storage.js';
+import { t } from './i18n.js';
+
+const $ = sel => document.querySelector(sel);
+let state = { selector: '', top: [], unique: false, textAlt: '', mode: 'get', domain: '' };
+
+async function init() {
+  $('#title').textContent = t('title');
+  $('#enableLabel').textContent = t('enablePicker');
+  $('#copySelector').textContent = t('copy');
+  $('#modeLabel').textContent = t('mode');
+  $('#copyPreview').textContent = t('copy');
+  $('#historyLabel').textContent = t('history');
+  $('#allowNthLabel').textContent = t('allowNth');
+  $('#maxDepthLabel').textContent = t('maxDepth');
+
+  const settings = await getSettings();
+  state.mode = settings.mode;
+  $('#allowNth').checked = settings.allowNth;
+  $('#maxDepth').value = settings.maxDepth;
+  document.querySelector(`input[name=mode][value=${state.mode}]`).checked = true;
+
+  chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+    try {
+      state.domain = new URL(tabs[0].url).hostname;
+      loadHistory();
+    } catch (e) {}
+  });
+
+  $('#pickerToggle').addEventListener('change', () => {
+    chrome.runtime.sendMessage({ type: 'TOGGLE_PICKER' });
+  });
+
+  $('#copySelector').addEventListener('click', () => {
+    navigator.clipboard.writeText(state.selector);
+  });
+
+  $('#copyPreview').addEventListener('click', copyPreview);
+
+  $('#allowNth').addEventListener('change', saveSettings);
+  $('#maxDepth').addEventListener('change', saveSettings);
+  document.querySelectorAll('input[name=mode]').forEach(r => r.addEventListener('change', e => {
+    state.mode = e.target.value;
+    setSettings({ mode: state.mode });
+    updatePreview();
+  }));
+
+  chrome.runtime.onMessage.addListener(msg => {
+    if (msg.type === 'PICKED') {
+      handlePicked(msg);
+    } else if (msg.type === 'MODE_CHANGED') {
+      state.mode = msg.mode;
+      document.querySelector(`input[name=mode][value=${state.mode}]`).checked = true;
+      updatePreview();
+    } else if (msg.type === 'COPY_SELECTED') {
+      copyPreview();
+    }
+  });
+}
+
+function copyPreview() {
+  navigator.clipboard.writeText($('#previewText').textContent);
+}
+
+function saveSettings() {
+  setSettings({ allowNth: $('#allowNth').checked, maxDepth: parseInt($('#maxDepth').value, 10), mode: state.mode });
+  chrome.runtime.sendMessage({ type: 'UPDATE_SETTINGS' });
+}
+
+async function loadHistory() {
+  const list = await getHistory(state.domain);
+  const ul = $('#historyList');
+  ul.innerHTML = '';
+  list.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = item.selector;
+    ul.appendChild(li);
+  });
+}
+
+function handlePicked(data) {
+  state.selector = data.selector;
+  state.top = data.top;
+  state.unique = data.unique;
+  state.textAlt = data.textAlt;
+  $('#bestSelector').value = data.selector;
+  $('#uniqueFlag').textContent = data.unique ? t('unique') : '';
+  const container = $('#topCandidates');
+  container.innerHTML = '';
+  data.top.forEach((sel, i) => {
+    const id = `cand${i}`;
+    const label = document.createElement('label');
+    const input = document.createElement('input');
+    input.type = 'radio';
+    input.name = 'cand';
+    input.value = sel;
+    if (i === 0) input.checked = true;
+    input.addEventListener('change', e => {
+      state.selector = e.target.value;
+      updatePreview();
+    });
+    label.appendChild(input);
+    label.append(sel);
+    container.appendChild(label);
+  });
+  updatePreview();
+  if (state.domain) {
+    pushHistory(state.domain, { selector: data.selector, text: data.textAlt });
+    loadHistory();
+  }
+  if (data.context === 'shadow') {
+    $('#contextWarning').textContent = t('shadowWarning');
+    $('#contextWarning').style.display = 'block';
+  } else if (data.context === 'iframe') {
+    $('#contextWarning').textContent = t('iframeWarning');
+    $('#contextWarning').style.display = 'block';
+  } else {
+    $('#contextWarning').style.display = 'none';
+  }
+}
+
+function updatePreview() {
+  const code = $('#previewText');
+  if (state.mode === 'get') {
+    code.textContent = `cy.get('${state.selector}')`;
+    code.classList.remove('disabled');
+  } else {
+    if (state.textAlt) {
+      code.textContent = `cy.contains('${state.textAlt}')`;
+      code.classList.remove('disabled');
+    } else {
+      code.textContent = `// ${t('noText')}`;
+      code.classList.add('disabled');
+    }
+  }
+}
+
+init();

--- a/src/selectorEngine.js
+++ b/src/selectorEngine.js
@@ -1,0 +1,94 @@
+import { escapeCss, escapeTextForContains, isProbablyRandomId, isNoisyClass, score } from './utils.js';
+
+export function buildCandidates(el, settings = { allowNth: false, maxDepth: 3 }) {
+  const tag = el.tagName.toLowerCase();
+  const out = new Set();
+
+  if (el.id && !isProbablyRandomId(el.id)) {
+    out.add(`#${escapeCss(el.id)}`);
+  }
+
+  const attrs = ['name', 'role', 'aria-label', 'title', 'placeholder', 'type', 'href', 'alt'];
+  for (const a of attrs) {
+    const v = el.getAttribute(a);
+    if (v) out.add(`${tag}[${a}="${escapeCss(v)}"]`);
+  }
+
+  const classes = [...el.classList].filter(c => !isNoisyClass(c));
+  if (classes.length) {
+    out.add(tag + classes.slice(0, 1).map(c => `.${escapeCss(c)}`).join(''));
+    if (classes.length > 1) out.add(tag + classes.slice(0, 2).map(c => `.${escapeCss(c)}`).join(''));
+  } else {
+    out.add(tag);
+  }
+
+  if (settings.allowNth && el.parentElement) {
+    const siblings = Array.from(el.parentElement.children).filter(s => s.tagName === el.tagName);
+    const idx = siblings.indexOf(el) + 1;
+    out.add(`${tag}:nth-of-type(${idx})`);
+  }
+
+  let parent = el.parentElement;
+  let depth = 0;
+  while (parent && depth < settings.maxDepth) {
+    depth++;
+    let parentSel = '';
+    if (parent.id && !isProbablyRandomId(parent.id)) {
+      parentSel = `#${escapeCss(parent.id)}`;
+    } else {
+      const cls = [...parent.classList].find(c => !isNoisyClass(c));
+      if (cls) parentSel = `${parent.tagName.toLowerCase()}.${escapeCss(cls)}`;
+    }
+    if (parentSel) {
+      out.add(`${parentSel} > ${tag}`);
+      break;
+    }
+    parent = parent.parentElement;
+  }
+
+  return Array.from(out);
+}
+
+export function isUnique(selector, root = document) {
+  try {
+    return root.querySelectorAll(selector).length === 1;
+  } catch (e) {
+    return false;
+  }
+}
+
+function calcPenalties(selector) {
+  let p = 0;
+  if (/:nth-of-type/.test(selector)) p += 30;
+  const depth = (selector.match(/>/g) || []).length + (selector.match(/\s/g) || []).length;
+  if (depth > 1) p += (depth - 1) * 10;
+  const classes = selector.match(/\.([a-zA-Z0-9_-]+)/g) || [];
+  classes.forEach(c => { if (isNoisyClass(c.slice(1))) p += 15; });
+  const id = selector.match(/#([a-zA-Z0-9_-]+)/);
+  if (id && isProbablyRandomId(id[1])) p += 20;
+  return p;
+}
+
+export function bestSelector(el, settings = { allowNth: false, maxDepth: 3 }) {
+  const candidates = buildCandidates(el, settings);
+  const root = el.getRootNode && el.getRootNode();
+  const contextRoot = root instanceof ShadowRoot ? root : document;
+
+  const scored = candidates.map(sel => {
+    const unique = isUnique(sel, contextRoot);
+    return { selector: sel, unique, score: score(sel, calcPenalties(sel)) };
+  });
+
+  let uniques = scored.filter(s => s.unique);
+  if (uniques.length === 0) uniques = scored;
+
+  uniques.sort((a, b) => a.score - b.score);
+  const top = uniques.slice(0, 3).map(s => s.selector);
+  return { selector: top[0] || '', top, unique: uniques[0]?.unique || false };
+}
+
+export function textBased(el) {
+  let text = (el.innerText || el.textContent || '').replace(/\s+/g, ' ').trim();
+  if (text.length > 100) text = text.slice(0, 100);
+  return escapeTextForContains(text);
+}

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,25 @@
+const DEFAULTS = { allowNth: false, maxDepth: 3, mode: 'get' };
+
+export async function getSettings() {
+  const data = await chrome.storage.sync.get(DEFAULTS);
+  return { ...DEFAULTS, ...data };
+}
+
+export async function setSettings(settings) {
+  await chrome.storage.sync.set(settings);
+}
+
+export async function pushHistory(domain, item) {
+  const key = `history:${domain}`;
+  const data = await chrome.storage.sync.get({ [key]: [] });
+  const list = data[key];
+  list.unshift(item);
+  if (list.length > 10) list.length = 10;
+  await chrome.storage.sync.set({ [key]: list });
+}
+
+export async function getHistory(domain) {
+  const key = `history:${domain}`;
+  const data = await chrome.storage.sync.get({ [key]: [] });
+  return data[key];
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,22 @@
+export function escapeCss(s = '') {
+  if (window.CSS && CSS.escape) return CSS.escape(s);
+  return s.replace(/([.#:[\],>+~=*^$|!\\])/g, '\\$1');
+}
+
+export function escapeTextForContains(s = '') {
+  return s.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+export function isProbablyRandomId(id = '') {
+  const uuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  const hash = /^[a-z0-9]{10,}$/i;
+  return uuid.test(id) || (hash.test(id) && !/[aeiou]{3}/i.test(id));
+}
+
+export function isNoisyClass(cls = '') {
+  return /^(css-|sc-|chakra-|Mui-|jss-|ant-|_[a-z0-9]{5,}|[a-z0-9]{6,})/i.test(cls);
+}
+
+export function score(selector, penalties = 0) {
+  return selector.length + penalties;
+}


### PR DESCRIPTION
## Summary
- add Manifest V3 extension for generating Cypress selectors
- implement selector engine, content and background scripts, popup UI with i18n and storage
- remove PNG icon assets and rely on default icon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689741fd2e38832398d6354230481763