### PR TITLE
Fix extension popup display

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "description": "Helper for generating unique CSS selectors for Cypress",
   "action": {
-    "default_title": "Cypress Selector Helper"
+    "default_title": "Cypress Selector Helper",
+    "default_popup": "src/popup.html"
   },
   "background": {
     "service_worker": "src/background.js",


### PR DESCRIPTION
## Summary
- ensure clicking the extension icon opens its popup

## Testing
- `npm test` (fails: package.json missing)

------
https://chatgpt.com/codex/tasks/task_e_68974e1e31688323a33ca8653bf74202