### PR TITLE
Add popup interface for selector actions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "description": "Helper for generating unique CSS selectors for Cypress",
   "action": {
-    "default_title": "Cypress Selector Helper"
+    "default_title": "Cypress Selector Helper",
+    "default_popup": "popup.html"
   },
   "background": {
     "service_worker": "src/background.js",

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Cypress Selector Helper</title>
+  <style>
+    body { min-width: 200px; font-family: sans-serif; margin: 10px; }
+    button { display: block; width: 100%; margin: 6px 0; padding: 6px; }
+  </style>
+</head>
+<body>
+  <button id="toggle">Toggle Picker</button>
+  <button id="copy">Copy Selector</button>
+  <button id="mode">Switch Mode</button>
+  <script src="src/popup.js"></script>
+</body>
+</html>

--- a/src/background.js
+++ b/src/background.js
@@ -15,6 +15,8 @@ chrome.commands.onCommand.addListener(async command => {
     const mode = s.mode === 'get' ? 'contains' : 'get';
     await setSettings({ mode });
     chrome.runtime.sendMessage({ type: 'MODE_CHANGED', mode });
+    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+    for (const tab of tabs) chrome.tabs.sendMessage(tab.id, { type: 'UPDATE_SETTINGS' });
   }
 });
 
@@ -30,6 +32,18 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
   } else if (msg.type === 'PICKED') {
     chrome.runtime.sendMessage(msg);
   } else if (msg.type === 'COPY_SELECTED') {
-    chrome.runtime.sendMessage(msg);
+    chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+      for (const tab of tabs) chrome.tabs.sendMessage(tab.id, msg);
+    });
+  } else if (msg.type === 'SWITCH_MODE') {
+    (async () => {
+      const s = await getSettings();
+      const mode = s.mode === 'get' ? 'contains' : 'get';
+      await setSettings({ mode });
+      chrome.runtime.sendMessage({ type: 'MODE_CHANGED', mode });
+      chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+        for (const tab of tabs) chrome.tabs.sendMessage(tab.id, { type: 'UPDATE_SETTINGS' });
+      });
+    })();
   }
 });

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,0 +1,5 @@
+const send = type => chrome.runtime.sendMessage({ type });
+
+document.getElementById('toggle').addEventListener('click', () => send('TOGGLE_PICKER'));
+document.getElementById('copy').addEventListener('click', () => send('COPY_SELECTED'));
+document.getElementById('mode').addEventListener('click', () => send('SWITCH_MODE'));


### PR DESCRIPTION
## Summary
- add popup.html and popup.js with controls to toggle picker, copy selectors, and switch modes
- wire background service worker to handle popup messages and update active tab settings
- expose popup via action default_popup in manifest

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689763e9003883238212d229c692ca6b